### PR TITLE
Add ferrothorn masking

### DIFF
--- a/handlers/ferrothorn.go
+++ b/handlers/ferrothorn.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ferrothorn_host               = strings.TrimSuffix(os.Getenv("FERROTHORN_HOST"), "/")
+	ferrothorn_mask               = strings.TrimSuffix(os.Getenv("FERROTHORN_MASK"), "/")
 	ferrothorn_secret             = os.Getenv("FERROTHORN_SECRET")
 	noFerrothorn                  = os.Getenv("NO_FERROTHORN") == "true"
 	requester         http.Client = http.Client{}
@@ -79,7 +80,11 @@ func upload(file io.Reader) (url string, err error) {
 
 	var response map[string]string
 	if response, err = ferroRequest(sendable); err == nil {
-		url = ferrothorn_host + "/" + response["id"]
+		if ferrothorn_mask != "" {
+			url = ferrothorn_mask + "/" + response["id"]
+		} else {
+			url = ferrothorn_host + "/" + response["id"]
+		}
 	}
 
 	return

--- a/handlers/ferrothorn_test.go
+++ b/handlers/ferrothorn_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"io"
+	"strings"
+	"testing"
+)
+
+type NopReader struct{}
+
+func (NopReader) Read(_ []byte) (_ int, err error) {
+	err = io.EOF
+	return
+}
+
+func Test_upload_prefix(test *testing.T) {
+	backupHost := ferrothorn_host
+	backupMask := ferrothorn_mask
+
+	defer func() {
+		ferrothorn_host = backupHost
+		ferrothorn_mask = backupMask
+	}()
+
+	ferrothorn_host = "host"
+	ferrothorn_mask = ""
+
+	url, err := upload(NopReader{})
+
+	if err != nil {
+		test.Fatal(err)
+	}
+
+	if !strings.HasPrefix(url, ferrothorn_host) {
+		test.Fatalf("url doesn't have %s prefix: %s", ferrothorn_mask, url)
+	}
+}
+
+func Test_upload_prefixMasked(test *testing.T) {
+	backupHost := ferrothorn_host
+	backupMask := ferrothorn_mask
+
+	defer func() {
+		ferrothorn_host = backupHost
+		ferrothorn_mask = backupMask
+	}()
+
+	ferrothorn_host = "host"
+	ferrothorn_mask = "mask"
+
+	url, err := upload(NopReader{})
+
+	if err != nil {
+		test.Fatal(err)
+	}
+
+	if strings.HasPrefix(url, ferrothorn_host) {
+		test.Fatalf("url still has %s prefix: %s", ferrothorn_host, url)
+	}
+
+	if !strings.HasPrefix(url, ferrothorn_mask) {
+		test.Fatalf("url doesn't have %s prefix: %s", ferrothorn_mask, url)
+	}
+}


### PR DESCRIPTION
Add the ability for ferrothorn to use a separate host than what it returns to the caller and stores in the database. This is useful in cases where the service might talk to ferrothorn over a cluster intranet

Add tests for masking