### PR TITLE
Do dynamic masking

### DIFF
--- a/handlers/ferrothorn.go
+++ b/handlers/ferrothorn.go
@@ -80,11 +80,7 @@ func upload(file io.Reader) (url string, err error) {
 
 	var response map[string]string
 	if response, err = ferroRequest(sendable); err == nil {
-		if ferrothorn_mask != "" {
-			url = ferrothorn_mask + "/" + response["id"]
-		} else {
-			url = ferrothorn_host + "/" + response["id"]
-		}
+		url = response["id"]
 	}
 
 	return

--- a/handlers/ferrothorn_test.go
+++ b/handlers/ferrothorn_test.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"io"
-	"strings"
 	"testing"
 )
 
@@ -14,51 +13,7 @@ func (NopReader) Read(_ []byte) (_ int, err error) {
 }
 
 func Test_upload_prefix(test *testing.T) {
-	backupHost := ferrothorn_host
-	backupMask := ferrothorn_mask
-
-	defer func() {
-		ferrothorn_host = backupHost
-		ferrothorn_mask = backupMask
-	}()
-
-	ferrothorn_host = "host"
-	ferrothorn_mask = ""
-
-	url, err := upload(NopReader{})
-
-	if err != nil {
+	if _, err := upload(NopReader{}); err != nil {
 		test.Fatal(err)
-	}
-
-	if !strings.HasPrefix(url, ferrothorn_host) {
-		test.Fatalf("url doesn't have %s prefix: %s", ferrothorn_mask, url)
-	}
-}
-
-func Test_upload_prefixMasked(test *testing.T) {
-	backupHost := ferrothorn_host
-	backupMask := ferrothorn_mask
-
-	defer func() {
-		ferrothorn_host = backupHost
-		ferrothorn_mask = backupMask
-	}()
-
-	ferrothorn_host = "host"
-	ferrothorn_mask = "mask"
-
-	url, err := upload(NopReader{})
-
-	if err != nil {
-		test.Fatal(err)
-	}
-
-	if strings.HasPrefix(url, ferrothorn_host) {
-		test.Fatalf("url still has %s prefix: %s", ferrothorn_host, url)
-	}
-
-	if !strings.HasPrefix(url, ferrothorn_mask) {
-		test.Fatalf("url doesn't have %s prefix: %s", ferrothorn_mask, url)
 	}
 }

--- a/handlers/get_content.go
+++ b/handlers/get_content.go
@@ -29,8 +29,16 @@ func GetContent(request *http.Request) (code int, r_map map[string]interface{}, 
 	}
 
 	code = 200
+
+	content := fetched.Map()
+	if ferrothorn_mask != "" {
+		content["file_url"] = ferrothorn_mask + "/" + fetched.FileURL
+	} else {
+		content["file_url"] = ferrothorn_host + "/" + fetched.FileURL
+	}
+
 	r_map = map[string]interface{}{
-		"content": fetched.Map(),
+		"content": content,
 	}
 	return
 }

--- a/handlers/post_content.go
+++ b/handlers/post_content.go
@@ -57,13 +57,13 @@ func makeContent(data, file io.Reader, author string) (created library_types.Con
 		return
 	}
 
-	var file_url string
-	if file_url, err = upload(&file_tee); err != nil {
+	var file_id string
+	if file_id, err = upload(&file_tee); err != nil {
 		return
 	}
 
 	created = library_types.NewContent(
-		file_url,
+		file_id,
 		author,
 		mime,
 		body.Tags,


### PR DESCRIPTION
Instead of constructing a file_url with a mask and storing it, only
store the ferrothorn file_id, and construct it with a mask or host at
runtime